### PR TITLE
Key and offset

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -7,15 +7,15 @@ class Enigma
   end
 
   def valid_key?(key)
-    valid_message?(key) &&
-    key.length == 5 &&
-    key.scan(/\D/).empty?
+    (key.size == 5) &&
+    (valid_message?(key)) &&
+    (key.scan(/\D./).empty?)
   end
 
   def valid_date?(date)
-    valid_message?(date) &&
-    date.length == 6 &&
-    date.scan(/\D/).empty?
+    (date.size == 6) &&
+    (valid_message?(date)) &&
+    (date.scan(/\D./).empty?)
   end
 
   def valid_input?(*inputs)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -41,21 +41,9 @@ class Enigma
     Date.today.strftime("%d%m%y")
   end
 
-  # date_squared(date)[-4..-1].to_i
-  #
-  # def numerical_date(date = Date.today)
-  #   # require "pry"; binding.pry
-  #   if date.class == String
-  #     date
-  #   else
-  #     date.strftime("%d%m%y")
-  #   end
-  # end
-  #
-  # def date_squared(date)
-  #   # require "pry"; binding.pry
-  #   ((numerical_date(date).to_i) * (numerical_date(date).to_i)).to_s
-  # end
-  #
+  def offset(date)
+    ((date.to_i) * (date.to_i)).to_s[-4..-1]
+  end
+  ## date_squared(date)[-4..-1].to_i
   #
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -44,6 +44,51 @@ class Enigma
   def offset(date)
     ((date.to_i) * (date.to_i)).to_s[-4..-1]
   end
-  ## date_squared(date)[-4..-1].to_i
-  #
+
+  def alphabet_array
+    Array("a".."z") << " "
+  end
+
+  def convert_message_to_numbers(message)
+    chars_message = message.downcase.chars
+    chars_message.map do |letter|
+     if alphabet_array.include?(letter)
+       alphabet_array.index(letter)
+     else
+       letter
+     end
+    end
+  end
+
+  #create Hash for keys and hash for offsets
+  # keys = {A: key[0..1], B: key[1..2], etc}.transform_values(&:to_i)
+  # offsets = {A: offset[0], B: offset[1], etc}.transform_values(&:to_i)
+
+  # Merge those two hashes together and add values to on another
+  # new_hash = keys.merge(offsets) {|letter, key, offset| key + offset}
+
+  #create an array of arrays that has the cipher codes for A-D
+  # rotated_letters = alpha.rotate(new_hash[value])
+  # cipher_arrays << rotated_letters
+
+  # create groups of letters_to_nums that will be zipped with cipher_arrays
+  # grouped_l_to_n = letters_to_nums.each_slice(4).map {|group| group}
+
+  # if that last element ends up having less than 4 elements move to own array
+  # leftovers = grouped_l_to_n.pop if grouped_l_to_n.last.size < 4
+
+  # iterate over grouped_l_to_n
+  # zip one group with ciper
+  # ciphered_msg = grouped_l_to_n.flat_map do |group|
+    # group.zip(cipher).map do |(group, cipher)|
+      # if group.class == Integer
+      #   cipher[group]
+      # else
+      #   group
+      # end
+    #end
+  #end
+
+  #zip leftovers with ciphers and add to end of ciphered_msg unless nil
+  # ciphered_msg.join
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -124,4 +124,12 @@ class EnigmaTest < Minitest::Test
 
     assert_equal expected, enigma.offset(date)
   end
+
+  def test_convert_message_to_numbers
+    enigma = Enigma.new
+    message = "Hello world"
+    converted = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
+
+    assert_equal converted, enigma.convert_message_to_numbers(message)
+  end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -62,7 +62,6 @@ class EnigmaTest < Minitest::Test
 
     assert_equal 6, date.length
     assert_equal String, date.class
-    # assert_equal date, enigma.generate_date
   end
 
   def test_it_has_valid_inputs?
@@ -83,12 +82,10 @@ class EnigmaTest < Minitest::Test
     enigma = Enigma.new
     valid = "Test"
     invalid1 = 1234
-    invalid2 = nil
 
     # assert_equal true, enigma.valid_message?(valid)
     assert_equal true, enigma.valid_message?(valid)
     assert_equal false, enigma.valid_message?(invalid1)
-    assert_equal false, enigma.valid_message?(invalid2)
   end
 
   def test_is_valid_key?
@@ -96,7 +93,7 @@ class EnigmaTest < Minitest::Test
     valid = "12345"
     invalid1 = "123456"
     invalid2 = 12345
-    invalid3 = nil
+    invalid3 = "A12345"
 
     assert_equal true, enigma.valid_key?(valid)
     assert_equal false, enigma.valid_key?(invalid1)
@@ -109,7 +106,7 @@ class EnigmaTest < Minitest::Test
     valid = "123456"
     invalid1 = "12345"
     invalid2 = 123456
-    invalid3 = nil
+    invalid3 = "123A56"
 
     assert_equal true, enigma.valid_date?(valid)
     assert_equal false, enigma.valid_date?(invalid1)

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -113,4 +113,15 @@ class EnigmaTest < Minitest::Test
     assert_equal false, enigma.valid_date?(invalid2)
     assert_equal false, enigma.valid_date?(invalid3)
   end
+
+  def test_it_convert_date_to_offset
+    enigma = Enigma.new
+    message = "hello world"
+    key = "02715"
+    date = "040895"
+    date_squared = (date.to_i) * (date.to_i)
+    expected = date_squared.to_s[-4..-1]
+
+    assert_equal expected, enigma.offset(date)
+  end
 end


### PR DESCRIPTION
- Fix regexp syntax in valid_key and valid_date so string values with only numbers that are correct size are accepted
    - i.e. "12345" is valid, "123V56" is invalid, "1234" is invalid
- Create tests and method to convert date to offset value
- Create tests and method to convert original message into numbers to be used for ciphered text