### PR TITLE
Create rotations and ciphers

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -67,6 +67,13 @@ class Enigma
       D: key[3..4] }.transform_values(&:to_i)
   end
 
+  def create_offsets(offset)
+    { A: offset[0],
+      B: offset[1],
+      C: offset[2],
+      D: offset[3] }.transform_values(&:to_i)
+  end
+
   #create Hash for keys and hash for offsets
   # keys = {A: key[0..1], B: key[1..2], etc}.transform_values(&:to_i)
   # offsets = {A: offset[0], B: offset[1], etc}.transform_values(&:to_i)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,6 +1,11 @@
 require 'date'
 
 class Enigma
+  attr_reader :encrypted_alphabets
+
+  def initialize
+    @encrypted_alphabets = []
+  end
 
   def valid_message?(message)
     message.class == String
@@ -41,10 +46,6 @@ class Enigma
     Date.today.strftime("%d%m%y")
   end
 
-  def offset(date)
-    ((date.to_i) * (date.to_i)).to_s[-4..-1]
-  end
-
   def alphabet_array
     Array("a".."z") << " "
   end
@@ -67,42 +68,31 @@ class Enigma
       D: key[3..4] }.transform_values(&:to_i)
   end
 
-  def create_offsets(offset)
+  def offset(date)
+    ((date.to_i) * (date.to_i)).to_s[-4..-1]
+  end
+
+  def create_offsets(date)
+    offset = offset(date)
     { A: offset[0],
       B: offset[1],
       C: offset[2],
       D: offset[3] }.transform_values(&:to_i)
   end
 
-  #create Hash for keys and hash for offsets
-  # keys = {A: key[0..1], B: key[1..2], etc}.transform_values(&:to_i)
-  # offsets = {A: offset[0], B: offset[1], etc}.transform_values(&:to_i)
+  def create_shifts(key, date)
+    create_keys(key).merge(create_offsets(date)) do |letter, key, offset|
+      key + offset
+    end
+  end
 
-  # Merge those two hashes together and add values to on another
-  # new_hash = keys.merge(offsets) {|letter, key, offset| key + offset}
+  def create_encrypted_alphabets(key, date)
+    shifts = create_shifts(key, date)
 
-  #create an array of arrays that has the cipher codes for A-D
-  # rotated_letters = alpha.rotate(new_hash[value])
-  # cipher_arrays << rotated_letters
+    shifts.values.each do |shift|
+      @encrypted_alphabets << alphabet_array.rotate(shift)
+    end
 
-  # create groups of letters_to_nums that will be zipped with cipher_arrays
-  # grouped_l_to_n = letters_to_nums.each_slice(4).map {|group| group}
-
-  # if that last element ends up having less than 4 elements move to own array
-  # leftovers = grouped_l_to_n.pop if grouped_l_to_n.last.size < 4
-
-  # iterate over grouped_l_to_n
-  # zip one group with ciper
-  # ciphered_msg = grouped_l_to_n.flat_map do |group|
-    # group.zip(cipher).map do |(group, cipher)|
-      # if group.class == Integer
-      #   cipher[group]
-      # else
-      #   group
-      # end
-    #end
-  #end
-
-  #zip leftovers with ciphers and add to end of ciphered_msg unless nil
-  # ciphered_msg.join
+    @encrypted_alphabets
+  end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -60,6 +60,13 @@ class Enigma
     end
   end
 
+  def create_keys(key)
+    { A: key[0..1],
+      B: key[1..2],
+      C: key[2..3],
+      D: key[3..4] }.transform_values(&:to_i)
+  end
+
   #create Hash for keys and hash for offsets
   # keys = {A: key[0..1], B: key[1..2], etc}.transform_values(&:to_i)
   # offsets = {A: offset[0], B: offset[1], etc}.transform_values(&:to_i)

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -128,9 +128,13 @@ class EnigmaTest < Minitest::Test
   def test_convert_message_to_numbers
     enigma = Enigma.new
     message = "Hello world"
-    converted = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
+    converted1 = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
 
-    assert_equal converted, enigma.convert_message_to_numbers(message)
+    assert_equal converted1, enigma.convert_message_to_numbers(message)
+
+    message = "Hello world!"
+    converted2 = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3, "!"]
+    assert_equal converted2, enigma.convert_message_to_numbers(message)
   end
 
   def test_keys_hash_when_key_date_provided
@@ -156,30 +160,44 @@ class EnigmaTest < Minitest::Test
     enigma = Enigma.new
     key = "02715"
     date = "040895"
-    offset = enigma.offset(date)
     expected = { A: 1, B: 0, C: 2, D: 5 }
-
-    assert_equal expected, enigma.create_offsets(offset)
+    Enigma.any_instance.stubs(:generate_date).returns("170121")
+    assert_equal expected, enigma.create_offsets(date)
   end
 
   def test_offset_hash_when_no_key_date_provided
     enigma = Enigma.new
     key = enigma.generate_key
+
     date = enigma.generate_date
-    offset = enigma.offset(date)
     expected = { A: 4, B: 6, C: 4, D: 1 }
 
-    assert_equal expected, enigma.create_offsets(offset)
+    assert_equal expected, enigma.create_offsets(date)
   end
 
   def test_create_shifts_hash
     enigma = Enigma.new
     key = "02715"
-    offset = "1025"
-    keys = enigma.create_keys(key)
-    offsets = enigma.create_offsets(offset)
+    date = "040895"
     expected = { A: 3, B: 27, C: 73, D: 20 }
 
-    assert_equal expected, enigma.create_shifts(keys, offsets)
+    assert_equal expected, enigma.create_shifts(key, date)
+  end
+
+  def test_create_encrypted_alphabets
+    enigma = Enigma.new
+    key = "02715"
+    date = "040895"
+    enigma.create_shifts(key, date)
+    enigma.create_encrypted_alphabets
+    expected1 = "d"
+    expected2 = "a"
+    expected3 = "t"
+    expected4 = "u"
+
+    assert_equal expected1, engima.encrypted_alphabets[0].first
+    assert_equal expected2, engima.encrypted_alphabets[1].first
+    assert_equal expected3, engima.encrypted_alphabets[2].first
+    assert_equal expected4, engima.encrypted_alphabets[3].first
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -156,9 +156,10 @@ class EnigmaTest < Minitest::Test
     enigma = Enigma.new
     key = "02715"
     date = "040895"
+    offset = enigma.offset(date)
     expected = { A: 1, B: 0, C: 2, D: 5 }
 
-    assert_equal expected, enigma.create_offsets(date)
+    assert_equal expected, enigma.create_offsets(offset)
   end
 
   def test_offset_hash_when_no_key_date_provided
@@ -166,8 +167,9 @@ class EnigmaTest < Minitest::Test
     # Enigma.any_instance.stubs(:generate_key).returns("67890")
     key = enigma.generate_key
     date = enigma.generate_date
+    offset = enigma.offset(date)
     expected = { A: 4, B: 6, C: 4, D: 1 }
 
-    assert_equal expected, enigma.create_offsets(date)
+    assert_equal expected, enigma.create_offsets(offset)
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -189,15 +189,15 @@ class EnigmaTest < Minitest::Test
     key = "02715"
     date = "040895"
     enigma.create_shifts(key, date)
-    enigma.create_encrypted_alphabets
+    enigma.create_encrypted_alphabets(key, date)
     expected1 = "d"
     expected2 = "a"
     expected3 = "t"
     expected4 = "u"
 
-    assert_equal expected1, engima.encrypted_alphabets[0].first
-    assert_equal expected2, engima.encrypted_alphabets[1].first
-    assert_equal expected3, engima.encrypted_alphabets[2].first
-    assert_equal expected4, engima.encrypted_alphabets[3].first
+    assert_equal expected1, enigma.encrypted_alphabets[0].first
+    assert_equal expected2, enigma.encrypted_alphabets[1].first
+    assert_equal expected3, enigma.encrypted_alphabets[2].first
+    assert_equal expected4, enigma.encrypted_alphabets[3].first
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -164,12 +164,22 @@ class EnigmaTest < Minitest::Test
 
   def test_offset_hash_when_no_key_date_provided
     enigma = Enigma.new
-    # Enigma.any_instance.stubs(:generate_key).returns("67890")
     key = enigma.generate_key
     date = enigma.generate_date
     offset = enigma.offset(date)
     expected = { A: 4, B: 6, C: 4, D: 1 }
 
     assert_equal expected, enigma.create_offsets(offset)
+  end
+
+  def test_create_shifts_hash
+    enigma = Enigma.new
+    key = "02715"
+    offset = "1025"
+    keys = enigma.create_keys(key)
+    offsets = enigma.create_offsets(offset)
+    expected = { A: 3, B: 27, C: 73, D: 20 }
+
+    assert_equal expected, enigma.create_shifts(keys, offsets)
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -135,12 +135,39 @@ class EnigmaTest < Minitest::Test
 
   def test_keys_hash_when_key_date_provided
     enigma = Enigma.new
-    message = "hello world"
     key = "02715"
     date = "040895"
-    enigma.encrypt(message, key, date)
     expected = { A: 2, B: 27, C: 71, D: 15 }
 
     assert_equal expected, enigma.create_keys(key)
+  end
+
+  def test_keys_hash_when_no_key_date_provided
+    enigma = Enigma.new
+    Enigma.any_instance.stubs(:generate_key).returns("67890")
+    key = enigma.generate_key
+    date = enigma.generate_date
+    expected = { A: 67, B: 78, C: 89, D: 90 }
+
+    assert_equal expected, enigma.create_keys(key)
+  end
+
+  def test_offset_hash_when_key_date_provided
+    enigma = Enigma.new
+    key = "02715"
+    date = "040895"
+    expected = { A: 1, B: 0, C: 2, D: 5 }
+
+    assert_equal expected, enigma.create_offsets(date)
+  end
+
+  def test_offset_hash_when_no_key_date_provided
+    enigma = Enigma.new
+    # Enigma.any_instance.stubs(:generate_key).returns("67890")
+    key = enigma.generate_key
+    date = enigma.generate_date
+    expected = { A: 4, B: 6, C: 4, D: 1 }
+
+    assert_equal expected, enigma.create_offsets(date)
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -114,7 +114,7 @@ class EnigmaTest < Minitest::Test
     assert_equal false, enigma.valid_date?(invalid3)
   end
 
-  def test_it_convert_date_to_offset
+  def test_it_converts_date_to_offset
     enigma = Enigma.new
     message = "hello world"
     key = "02715"
@@ -131,5 +131,16 @@ class EnigmaTest < Minitest::Test
     converted = [7, 4, 11, 11, 14, 26, 22, 14, 17, 11, 3]
 
     assert_equal converted, enigma.convert_message_to_numbers(message)
+  end
+
+  def test_keys_hash_when_key_date_provided
+    enigma = Enigma.new
+    message = "hello world"
+    key = "02715"
+    date = "040895"
+    enigma.encrypt(message, key, date)
+    expected = { A: 2, B: 27, C: 71, D: 15 }
+
+    assert_equal expected, enigma.create_keys(key)
   end
 end


### PR DESCRIPTION
- Add tests and method to create keys and offsets hashes
- Add tests and method to merge keys & offsets values in new hash to use as shifts
- Add tests and method to rotate alphabet arrays using shifts for A-D respectively, store in @encrypted_alphabets
- Make @encrypted_alphabets able to read
- Add test for convert_message_to_numbers to validate symbols like ! are not converted or discarded
